### PR TITLE
Allow sorting of locations

### DIFF
--- a/_data/2020/beijing/location.yml
+++ b/_data/2020/beijing/location.yml
@@ -4,3 +4,4 @@ subtitle: Beijing, China
 description: ""
 link: beijing
 year: 2020
+order: 99

--- a/_data/2020/copenhagen/location.yml
+++ b/_data/2020/copenhagen/location.yml
@@ -4,3 +4,4 @@ subtitle: Copenhagen, Denmark
 description: ""
 link: copenhagen
 year: 2020
+order: 99

--- a/_data/2020/helsinki/location.yml
+++ b/_data/2020/helsinki/location.yml
@@ -4,3 +4,4 @@ subtitle: Helsinki, Finland
 description: ""
 link: helsinki
 year: 2020
+order: 99

--- a/_data/2020/konstanz/location.yml
+++ b/_data/2020/konstanz/location.yml
@@ -4,3 +4,4 @@ subtitle: Konstanz, Germany
 description: ""
 link: konstanz
 year: 2020
+order: 99

--- a/_data/2020/milano/location.yml
+++ b/_data/2020/milano/location.yml
@@ -4,3 +4,4 @@ subtitle: Milan, Italy
 description: ""
 link: milano
 year: 2020
+order: 99

--- a/_data/2020/nyu/location.yml
+++ b/_data/2020/nyu/location.yml
@@ -4,3 +4,4 @@ subtitle: New York, New York
 description: ""
 link: nyu
 year: 2020
+order: 99

--- a/_data/2020/paris/location.yml
+++ b/_data/2020/paris/location.yml
@@ -4,3 +4,4 @@ subtitle: Plateau de Saclay, France
 description: ""
 link: paris
 year: 2020
+order: 99

--- a/_data/2020/princeton/location.yml
+++ b/_data/2020/princeton/location.yml
@@ -4,3 +4,4 @@ subtitle: Princeton, New Jersey
 description: ""
 link: princeton
 year: 2020
+order: 99

--- a/_data/2020/stellenbosch/location.yml
+++ b/_data/2020/stellenbosch/location.yml
@@ -4,3 +4,4 @@ subtitle: Stellenbosch, South Africa
 description: "From 15 to 26 June 2020, the Department of Information Science at Stellenbosch University will host a partner event for the Summer Institute in Computational Social Science."
 link: stellenbosch
 year: 2020
+order: 99

--- a/_data/2020/tokyo/location.yml
+++ b/_data/2020/tokyo/location.yml
@@ -4,3 +4,4 @@ subtitle: Yokohama, Japan
 description: ""
 link: tokyo
 year: 2020
+order: 99

--- a/_includes/apply_list_group.html
+++ b/_includes/apply_list_group.html
@@ -1,8 +1,8 @@
 {% for year in locations_by_year %}
   <ul>
     {% for year_location in year.locations %}
-      {% assign apply_data = site.data[year.year][year_location.slug].apply %}
-      {% assign location_data = site.data[year.year][year_location.slug].location %}
+      {% assign apply_data = year_location.apply %}
+      {% assign location_data = year_location.location %}
       {% if apply_data.title %}
         <li><a href={{site.baseurl}}/{{location_data.year}}/{{location_data.link}}/apply>{{location_data.title}}</a></li>
       {% endif %}

--- a/_includes/apply_list_group.html
+++ b/_includes/apply_list_group.html
@@ -1,9 +1,8 @@
-{% for year_num in (2017..site.current_year) reversed %}
-  {% assign allyears = year_num | downcase %}
+{% for year in locations_by_year %}
   <ul>
-    {% for year in site.data[allyears] %}
-      {% assign apply_data = year[1].apply %}
-      {% assign location_data = year[1].location %}
+    {% for year_location in year.locations %}
+      {% assign apply_data = site.data[year.year][year_location.slug].apply %}
+      {% assign location_data = site.data[year.year][year_location.slug].location %}
       {% if apply_data.title %}
         <li><a href={{site.baseurl}}/{{location_data.year}}/{{location_data.link}}/apply>{{location_data.title}}</a></li>
       {% endif %}

--- a/_includes/locations_two_column.html
+++ b/_includes/locations_two_column.html
@@ -1,16 +1,11 @@
-{% for year_num in (2017..site.current_year) reversed %}
-  {% assign index_mod_2 = forloop.index | modulo: 2 %}
-  {% if index_mod_2 == 1 %}
-  {% endif %}
-    {% assign allyears = year_num | downcase %}
-      <div class="col-sm-12">
-        <h1 id="{{allyears}}">{{allyears}}</h1>
-      </div>
-    {% for year in site.data[allyears] %}
-    {% assign location_data = year[1].location %}
-    {% assign apply_data = year[1].apply %}
-      {% include locations_listing.html location_data=location_data apply_data=apply_data year=year %}
+{% for year in locations_by_year %}
+
+  <div class="col-sm-12">
+    <h1 id="{{year.year}}">{{year.year}}</h1>
+  </div>
+    {% for year_location in year.locations %}
+    {% assign location_data = site.data[year.year][year_location.slug].location %}
+    {% assign apply_data = site.data[year.year][year_location.slug].apply %}
+      {% include locations_listing.html location_data=location_data apply_data=apply_data year=year.year %}
     {% endfor %}
-  {% if index_mod_2 == 0 or forloop.last %}
-  {% endif %}
 {% endfor %}

--- a/_includes/locations_two_column.html
+++ b/_includes/locations_two_column.html
@@ -4,8 +4,8 @@
     <h1 id="{{year.year}}">{{year.year}}</h1>
   </div>
     {% for year_location in year.locations %}
-    {% assign location_data = site.data[year.year][year_location.slug].location %}
-    {% assign apply_data = site.data[year.year][year_location.slug].apply %}
+    {% assign location_data = year_location.location %}
+    {% assign apply_data = year_location.apply %}
       {% include locations_listing.html location_data=location_data apply_data=apply_data year=year.year %}
     {% endfor %}
 {% endfor %}

--- a/_includes/makehash.inc
+++ b/_includes/makehash.inc
@@ -1,0 +1,1 @@
+{% assign h = include %}

--- a/_includes/people_listing_all.html
+++ b/_includes/people_listing_all.html
@@ -27,23 +27,23 @@
   {% endfor %}
 </div>
 
-{% for year_num in (2017..site.current_year) reversed %}
-{% assign allyears = year_num | downcase %}
+{% for year in locations_by_year %}
 <div class="row">
   <div class="col-sm-12">
-    <h1 id="{{allyears}}">{{allyears}}</h1>
+    <h1 id="{{year.year}}">{{year.year}}</h1>
     <br />
   </div>
-{% for year in site.data[allyears] %}
+{% for year_location in year.locations %}
+  {% assign location = site.data[year.year][year_location.slug] %}
   <div class="col-sm-12">
-    <h2 id="{{year[1].location.link}}{{year[1].location.year}}">{{year[1].location.title}}</h2>
-    <h4 id={{group[0]}} class="h3 mb-4">All Participants 
+    <h2 id="{{location.location.link}}{{location.location.year}}">{{location.location.title}}</h2>
+    <h4 class="h3 mb-4">All Participants
       <!-- <small class="text-muted font-weight-light">(Listed alphabetically)</small> -->
     </h4>
     <hr />
   </div>
-  {% if year[1].people %}
-    {% assign people_data = year[1].people %}
+  {% if location.people %}
+    {% assign people_data = location.people %}
     {% for group in people_data %}
       {% assign people = group[1].people %}
       {% if people %}
@@ -71,10 +71,10 @@
       {% endif %}
     {% endfor %}
     {% else %}
-      {% assign faculty = year[1].faculty %}
-      {% assign speakers = year[1].speakers %}
-      {% assign participants = year[1].participants %}
-      {% assign teaching_assistants = year[1].teaching_assistants %}
+      {% assign faculty = location.faculty %}
+      {% assign speakers = location.speakers %}
+      {% assign participants = location.participants %}
+      {% assign teaching_assistants = location.teaching_assistants %}
         {% for person in faculty %}
           <div class="media mb-5">
             {% if person.image %}

--- a/_includes/people_listing_all.html
+++ b/_includes/people_listing_all.html
@@ -34,7 +34,7 @@
     <br />
   </div>
 {% for year_location in year.locations %}
-  {% assign location = site.data[year.year][year_location.slug] %}
+  {% assign location = year_location %}
   <div class="col-sm-12">
     <h2 id="{{location.location.link}}{{location.location.year}}">{{location.location.title}}</h2>
     <h4 class="h3 mb-4">All Participants

--- a/_includes/setup_locations_by_year.inc
+++ b/_includes/setup_locations_by_year.inc
@@ -1,0 +1,20 @@
+{% assign locations_by_year = '' | split: '.' %}
+{% for year_num in (2017..site.current_year) reversed %}
+    {% assign year_str = year_num | downcase %}
+
+    {% comment %}
+    We want to sort locations by their "order" key and secondarily by their "title".
+    We combine the "order" and "title" into a single string to sort by. The "order" must be
+    zero padded so that they sort as expected when converted to a string.
+    {% endcomment %}
+    {% assign year_locations = '' | split: '.' %}
+    {% for location in site.data[year_str] %}
+      {% assign order = location[1].location.order | default: 98 | prepend: '0000' | slice: -4, 4 | append: location[1].location.title %}
+      {% assign slug = location[0] %}
+      {% include makehash.inc slug=slug order=order %}
+      {% assign year_locations = year_locations | push: h %}
+    {% endfor %}
+    {% assign year_locations = year_locations | sort: "order" %}
+    {% include makehash.inc year=year_str locations=year_locations %}
+    {% assign locations_by_year = locations_by_year | push: h %}
+{% endfor %}

--- a/_includes/setup_locations_by_year.inc
+++ b/_includes/setup_locations_by_year.inc
@@ -15,6 +15,11 @@
       {% assign year_locations = year_locations | push: h %}
     {% endfor %}
     {% assign year_locations = year_locations | sort: "order" %}
-    {% include makehash.inc year=year_str locations=year_locations %}
+    {% assign year_location_array = '' | split: '.' %}
+    {% for year_location in year_locations %}
+        {% assign year_location_item = site.data[year_str][year_location.slug] %}
+        {% assign year_location_array = year_location_array | push: year_location_item %}
+    {% endfor %}
+    {% include makehash.inc year=year_str locations=year_location_array %}
     {% assign locations_by_year = locations_by_year | push: h %}
 {% endfor %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -47,7 +47,7 @@
       <a class="nav-link" onmouseover="" style="cursor: pointer;" data-toggle="collapse" data-target="#collapse{{forloop.index}}">{{year.year}}</a>
       <ul class="nav collapse" id="collapse{{forloop.index}}" aria-labelledby="{{forloop.index}}" data-parent="#accordionMenu">
       {% for year_location in year.locations %}
-      {% assign campus = site.data[year.year][year_location.slug].location %}
+      {% assign campus = year_location.location %}
         {% if campus.title %}
         <li class="nav-item w-100">
           <a class="nav-link" href="#{{campus.link}}_{{campus.year}}">{{campus.title}}
@@ -117,7 +117,7 @@
             <a class="nav-link" onmouseover="" style="cursor: pointer;" data-toggle="collapse" data-target="#collapse{{forloop.index}}">{{year.year}}</a>
             <ul class="nav collapse" id="collapse{{forloop.index}}" aria-labelledby="{{forloop.index}}" data-parent="#accordionMenu">
             {% for year_location in year.locations %}
-            {% assign campus = site.data[year.year][year_location.slug].location %}
+            {% assign campus = year_location.location %}
 
               {% if campus.title %}
               <li class="nav-item w-100">

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -42,14 +42,12 @@
 <!-- locations sidebar -->
 {% if page.layout == 'locations' %}
   <ul class="nav flex-column" id="accordionMenu">
-  {% for year_num in (2017..site.current_year) reversed %}
-    {% assign year = year_num | downcase %}
+  {% for year in locations_by_year %}
     <li class="nav-item">
-      <a class="nav-link" onmouseover="" style="cursor: pointer;" data-toggle="collapse" data-target="#collapse{{forloop.index}}">{{year}}</a>
+      <a class="nav-link" onmouseover="" style="cursor: pointer;" data-toggle="collapse" data-target="#collapse{{forloop.index}}">{{year.year}}</a>
       <ul class="nav collapse" id="collapse{{forloop.index}}" aria-labelledby="{{forloop.index}}" data-parent="#accordionMenu">
-      {% for single_year in site.data[year] %}
-      {% assign location_data = single_year[1].location %}
-      {% assign campus = location_data %}
+      {% for year_location in year.locations %}
+      {% assign campus = site.data[year.year][year_location.slug].location %}
         {% if campus.title %}
         <li class="nav-item w-100">
           <a class="nav-link" href="#{{campus.link}}_{{campus.year}}">{{campus.title}}
@@ -87,13 +85,13 @@
     </li>
     <li class="nav-item">
       <a class="nav-link" href="#day_5">Mass Collaboration</a>
-    </li>  
+    </li>
     <li class="nav-item">
       <a class="nav-link" href="#day_6">Experiments in the Digital Age</a>
-    </li>  
+    </li>
     <li class="nav-item">
       <a class="nav-link" href="#bonus_lectures">Bonus Lectures by Leaders in the Field</a>
-    </li> 
+    </li>
   </ul>
 {% endif %}
 
@@ -114,14 +112,12 @@
   {% else %}
     <div class="col-md-4">
       <ul class="nav flex-column" id="accordionMenu">
-        {% for year_num in (2017..site.current_year) reversed %}
-          {% assign year = year_num | downcase %}
+        {% for year in locations_by_year %}
           <li class="nav-item">
-            <a class="nav-link" onmouseover="" style="cursor: pointer;" data-toggle="collapse" data-target="#collapse{{forloop.index}}">{{year}}</a>
+            <a class="nav-link" onmouseover="" style="cursor: pointer;" data-toggle="collapse" data-target="#collapse{{forloop.index}}">{{year.year}}</a>
             <ul class="nav collapse" id="collapse{{forloop.index}}" aria-labelledby="{{forloop.index}}" data-parent="#accordionMenu">
-            {% for single_year in site.data[year] %}
-            {% assign location_data = single_year[1].location %}
-            {% assign campus = location_data %}
+            {% for year_location in year.locations %}
+            {% assign campus = site.data[year.year][year_location.slug].location %}
 
               {% if campus.title %}
               <li class="nav-item w-100">

--- a/_layouts/apply.html
+++ b/_layouts/apply.html
@@ -1,4 +1,5 @@
 {% include setup_data.html %}
+{% include setup_locations_by_year.inc %}
 <!DOCTYPE html>
 <html lang="en" class="year_{{ year }}">
   <head>
@@ -23,7 +24,7 @@
             </li>
           </ul>
         </div>
-        
+
         <div class="col-md-8 mb-5">
           {{content}}
 

--- a/_layouts/locations.html
+++ b/_layouts/locations.html
@@ -1,4 +1,5 @@
 {% include setup_data.html %}
+{% include setup_locations_by_year.inc %}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -11,7 +12,7 @@
     <div class="container">
       <div class="row">
         <div class="col-md-4">
-          {% include sidebar.html %} 
+          {% include sidebar.html %}
         </div>
         <div class="col-sm-8">
           <h2 class="display-4">Locations, past and present</h2>

--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -1,4 +1,5 @@
 {% include setup_data.html %}
+{% include setup_locations_by_year.inc %}
 <!doctype html>
 <html lang="en">
   <head>
@@ -8,7 +9,7 @@
     {% include navbar.html %}
     {% include hero_secondary.html %}
   <!-- Start content -->
-  <section>  
+  <section>
     <div class="container">
       <div class="row">
         {% include sidebar.html %}


### PR DESCRIPTION
Fixes #1988

@msalganik This pull request fixes #1988. Whenever we list locations by year, we have a mechanism for sorting the locations in that year. The order is determined first by the location's `order` key in their `location.yml` file and secondly by the location's title. In other words, the "title" is the the tie break. I went ahead and gave all the postponed locations an `order` of 99, so they'll be sorted last. Because they all have the same `order`, the list of postponed locations will be sorted by their title.

This sorting affects the sidebar and the content.

I'll merge this now, but feel free to tinker with this or let me know if you'd like me to alter how this works.