### PR TITLE
Remove website button in bios; name clickable

### DIFF
--- a/_includes/people_listing.html
+++ b/_includes/people_listing.html
@@ -8,32 +8,14 @@
   <h3 id={{group[0]}} class="h3 mb-4">{{group[1].title}}</h3>
   {% else %}
   <hr class="mt-5 mb-4">
-  <h3 id={{group[0]}} class="h3 mb-4">{{group[1].title}} 
+  <h3 id={{group[0]}} class="h3 mb-4">{{group[1].title}}
     <!-- <small class="text-muted font-weight-light">(Listed alphabetically)</small> -->
   </h3>
   {% endif %}
   {% assign people = group[1].people %}
   {% if people %}
-    {% for card in people %}
-      <div class="media mb-5">
-        {% if card.image %}
-        {% assign image_prefix = card.image | slice: 0, 4 %}
-        {% if image_prefix == "http" %}
-          {% assign image_url = card.image %}
-        {% else %}
-          {% assign image_url = card.image | prepend: site.baseurl %}
-        {% endif %}
-        <img src="{{ image_url }}" alt="Image of {{ card.name }}" class="mr-5 rounded" width="150">
-        {% endif %}
-        <div class="media-body">
-          <h5 class="mt-0 font-weight-bold">{{card.name}}</h5>
-          {{card.bio}}
-          <br>
-          {% if card.website %}
-          <a href={{card.website}} target="_blank" class="btn btn-sm btn-dark mt-3">Website</a>
-          {% endif %}
-        </div>
-      </div>
+    {% for person in people %}
+      {% include person.html person=person %}
     {% endfor %}
   {% endif %}
 {% endfor %}
@@ -46,32 +28,14 @@
     <!-- add searchar.html post release  -->
     {% else %}
     <hr class="mt-5 mb-4">
-    <h3 id={{group[0]}} class="h3 mb-4">{{group[1].title}} 
+    <h3 id={{group[0]}} class="h3 mb-4">{{group[1].title}}
       <!-- <small class="text-muted font-weight-light">(Listed alphabetically)</small> -->
     </h3>
     {% endif %}
     {% assign people = group[1].people %}
     {% if people %}
-      {% for card in people %}
-        <div class="media mb-5">
-          {% if card.image %}
-          {% assign image_prefix = card.image | slice: 0, 4 %}
-          {% if image_prefix == "http" %}
-            {% assign image_url = card.image %}
-          {% else %}
-            {% assign image_url = card.image | prepend: site.baseurl %}
-          {% endif %}
-          <img src="{{ image_url }}" alt="Image of {{ card.name }}" class="mr-5 rounded" width="150">
-          {% endif %}
-          <div class="media-body">
-            <h5 class="mt-0 font-weight-bold">{{card.name}}</h5>
-            {{card.bio}}
-            <br>
-            {% if card.website %}
-            <a href={{card.website}} target="_blank" class="btn btn-sm btn-dark mt-3">Website</a>
-            {% endif %}
-          </div>
-        </div>
+      {% for person in people %}
+        {% include person.html person=person %}
       {% endfor %}
     {% endif %}
   {% endfor %}

--- a/_includes/people_listing_all.html
+++ b/_includes/people_listing_all.html
@@ -5,25 +5,7 @@
     <br />
   </div>
   {% for leader in data.leadership %}
-    <div class="media mb-5">
-      {% if leader.image %}
-      {% assign image_prefix = leader.image | slice: 0, 4 %}
-      {% if image_prefix == "http" %}
-        {% assign image_url = leader.image %}
-      {% else %}
-        {% assign image_url = leader.image | prepend: site.baseurl %}
-      {% endif %}
-      <img src="{{ image_url }}" alt="Image of {{ leader.name }}" class="mr-5 rounded" width="150">
-      {% endif %}
-      <div class="media-body">
-        <h5 class="mt-0 font-weight-bold">{{leader.name}}</h5>
-        {{leader.bio}}
-        <br>
-        {% if leader.website %}
-        <a href={{leader.website}} target="_blank" class="btn btn-sm btn-dark mt-3">Website</a>
-        {% endif %}
-      </div>
-    </div>
+    {% include person.html person=leader %}
   {% endfor %}
 </div>
 
@@ -47,26 +29,8 @@
     {% for group in people_data %}
       {% assign people = group[1].people %}
       {% if people %}
-        {% for card in people %}
-          <div class="media mb-5">
-            {% if card.image %}
-            {% assign image_prefix = card.image | slice: 0, 4 %}
-            {% if image_prefix == "http" %}
-              {% assign image_url = card.image %}
-            {% else %}
-              {% assign image_url = card.image | prepend: site.baseurl %}
-            {% endif %}
-            <img src="{{ image_url }}" alt="Image of {{ card.name }}" class="mr-5 rounded" width="150">
-            {% endif %}
-            <div class="media-body">
-              <h5 class="mt-0 font-weight-bold">{{card.name}}</h5>
-              {{card.bio}}
-              <br>
-              {% if card.website %}
-              <a href={{card.website}} target="_blank" class="btn btn-sm btn-dark mt-3">Website</a>
-              {% endif %}
-            </div>
-          </div>
+        {% for person in people %}
+          {% include person.html person=person %}
         {% endfor %}
       {% endif %}
     {% endfor %}
@@ -75,89 +39,17 @@
       {% assign speakers = location.speakers %}
       {% assign participants = location.participants %}
       {% assign teaching_assistants = location.teaching_assistants %}
-        {% for person in faculty %}
-          <div class="media mb-5">
-            {% if person.image %}
-            {% assign image_prefix = person.image | slice: 0, 4 %}
-            {% if image_prefix == "http" %}
-              {% assign image_url = person.image %}
-            {% else %}
-              {% assign image_url = person.image | prepend: site.baseurl %}
-            {% endif %}
-            <img src="{{ image_url }}" alt="Image of {{ person.name }}" class="mr-5 rounded" width="150">
-            {% endif %}
-            <div class="media-body">
-              <h5 class="mt-0 font-weight-bold">{{person.name}}</h5>
-              {{person.bio}}
-              <br>
-              {% if person.website %}
-              <a href={{person.website}} target="_blank" class="btn btn-sm btn-dark mt-3">Website</a>
-              {% endif %}
-            </div>
-          </div>
-        {% endfor %}
-        {% for person in speakers %}
-        <div class="media mb-5">
-          {% if person.image %}
-          {% assign image_prefix = person.image | slice: 0, 4 %}
-          {% if image_prefix == "http" %}
-            {% assign image_url = person.image %}
-          {% else %}
-            {% assign image_url = person.image | prepend: site.baseurl %}
-          {% endif %}
-          <img src="{{ image_url }}" alt="Image of {{ person.name }}" class="mr-5 rounded" width="150">
-          {% endif %}
-          <div class="media-body">
-            <h5 class="mt-0 font-weight-bold">{{person.name}}</h5>
-            {{person.bio}}
-            <br>
-            {% if person.website %}
-            <a href={{person.website}} target="_blank" class="btn btn-sm btn-dark mt-3">Website</a>
-            {% endif %}
-          </div>
-        </div>
+      {% for person in faculty %}
+        {% include person.html person=person %}
+      {% endfor %}
+      {% for person in speakers %}
+        {% include person.html person=person %}
       {% endfor %}
       {% for person in participants %}
-        <div class="media mb-5">
-          {% if person.image %}
-          {% assign image_prefix = person.image | slice: 0, 4 %}
-          {% if image_prefix == "http" %}
-            {% assign image_url = person.image %}
-          {% else %}
-            {% assign image_url = person.image | prepend: site.baseurl %}
-          {% endif %}
-          <img src="{{ image_url }}" alt="Image of {{ person.name }}" class="mr-5 rounded" width="150">
-          {% endif %}
-          <div class="media-body">
-            <h5 class="mt-0 font-weight-bold">{{person.name}}</h5>
-            {{person.bio}}
-            <br>
-            {% if person.website %}
-            <a href={{person.website}} target="_blank" class="btn btn-sm btn-dark mt-3">Website</a>
-            {% endif %}
-          </div>
-        </div>
+        {% include person.html person=person %}
       {% endfor %}
       {% for person in teaching_assistants %}
-        <div class="media mb-5">
-          {% if person.image %}
-          {% assign image_prefix = person.image | slice: 0, 4 %}
-          {% if image_prefix == "http" %}
-            {% assign image_url = person.image %}
-          {% else %}
-            {% assign image_url = person.image | prepend: site.baseurl %}
-          {% endif %}
-          <img src="{{ image_url }}" alt="Image of {{ person.name }}" class="mr-5 rounded" width="150">
-          {% endif %}
-          <div class="media-body">
-            <h5 class="mt-0 font-weight-bold">{{person.name}}</h5>
-            {{person.bio}}
-            <br>
-            {% if person.website %}
-            <a href={{person.website}} target="_blank" class="btn btn-sm btn-dark mt-3">Website</a>
-            {% endif %}
-          </div>
-        </div>
+        {% include person.html person=person %}
       {% endfor %}
   {% endif %}
 {% endfor %}

--- a/_includes/people_listing_secondary.html
+++ b/_includes/people_listing_secondary.html
@@ -30,23 +30,5 @@
   <!-- <small class="text-muted font-weight-light">(Listed alphabetically)</small> -->
 </h3>
 {% for person in people %}
-  <div class="media mb-5">
-    {% if person.image %}
-    {% assign image_prefix = person.image | slice: 0, 4 %}
-    {% if image_prefix == "http" %}
-      {% assign image_url = person.image %}
-    {% else %}
-      {% assign image_url = person.image | prepend: site.baseurl %}
-    {% endif %}
-    <img src="{{ image_url }}" alt="Image of {{ person.name }}" class="mr-5 rounded" width="150">
-    {% endif %}
-    <div class="media-body">
-      <h5 class="mt-0 font-weight-bold">{{person.name}}</h5>
-      {{person.bio}}
-      <br>
-      {% if person.website %}
-      <a href={{person.website}} target="_blank" class="btn btn-sm btn-dark mt-3">Website</a>
-      {% endif %}
-    </div>
-  </div>
+  {% include person.html person=person %}
 {% endfor %}

--- a/_includes/person.html
+++ b/_includes/person.html
@@ -1,0 +1,21 @@
+<div class="media mb-5">
+  {% if include.person.image %}
+  {% assign image_prefix = include.person.image | slice: 0, 4 %}
+  {% if image_prefix == "http" %}
+    {% assign image_url = include.person.image %}
+  {% else %}
+    {% assign image_url = include.person.image | prepend: site.baseurl %}
+  {% endif %}
+  <img src="{{ image_url }}" alt="Image of {{ include.person.name }}" class="mr-5 rounded" width="150">
+  {% endif %}
+  <div class="media-body">
+    <h5 class="mt-0 font-weight-bold">
+      {% if include.person.website %}
+        <a href={{include.person.website}} target="_blank" rel="noopener noreferrer">{{include.person.name}}</a>
+      {% else %}
+        {{include.person.name}}
+      {% endif %}
+    </h5>
+    {{include.person.bio}}
+  </div>
+</div>


### PR DESCRIPTION
Fixes #1989 

@msalganik, this removes the "Website" button in the bios and makes the person's name a link if they have a link in their bio. In the screenshot below, you can see two bios. The first has a link and the second does not.

I'll merge this immediately, but feel free to offer suggestions for changes.

![Screenshot from 2020-04-24 11-01-14](https://user-images.githubusercontent.com/84748/80227253-6120cd00-861b-11ea-88ff-8b039eecbe63.png)
