### PR TITLE
Add ability to hide apply button

### DIFF
--- a/_data/2020/beijing/location.yml
+++ b/_data/2020/beijing/location.yml
@@ -5,3 +5,4 @@ description: ""
 link: beijing
 year: 2020
 order: 99
+apply_button: hidden

--- a/_data/2020/chicago/location.yml
+++ b/_data/2020/chicago/location.yml
@@ -5,3 +5,4 @@ description: ""
 link: chicago
 year: 2020
 order: 99
+apply_button: hidden

--- a/_data/2020/copenhagen/location.yml
+++ b/_data/2020/copenhagen/location.yml
@@ -5,3 +5,4 @@ description: ""
 link: copenhagen
 year: 2020
 order: 99
+apply_button: hidden

--- a/_data/2020/helsinki/location.yml
+++ b/_data/2020/helsinki/location.yml
@@ -5,3 +5,4 @@ description: ""
 link: helsinki
 year: 2020
 order: 99
+apply_button: hidden

--- a/_data/2020/hse/location.yml
+++ b/_data/2020/hse/location.yml
@@ -5,3 +5,4 @@ description: ""
 link: hse
 year: 2020
 order: 99
+apply_button: hidden

--- a/_data/2020/konstanz/location.yml
+++ b/_data/2020/konstanz/location.yml
@@ -5,3 +5,4 @@ description: ""
 link: konstanz
 year: 2020
 order: 99
+apply_button: hidden

--- a/_data/2020/milano/location.yml
+++ b/_data/2020/milano/location.yml
@@ -5,3 +5,4 @@ description: ""
 link: milano
 year: 2020
 order: 99
+apply_button: hidden

--- a/_data/2020/nyu/location.yml
+++ b/_data/2020/nyu/location.yml
@@ -5,3 +5,4 @@ description: ""
 link: nyu
 year: 2020
 order: 99
+apply_button: hidden

--- a/_data/2020/oxford/location.yml
+++ b/_data/2020/oxford/location.yml
@@ -5,3 +5,4 @@ description: ""
 link: oxford
 year: 2020
 order: 99
+apply_button: hidden

--- a/_data/2020/paris/location.yml
+++ b/_data/2020/paris/location.yml
@@ -5,3 +5,4 @@ description: ""
 link: paris
 year: 2020
 order: 99
+apply_button: hidden

--- a/_data/2020/princeton/location.yml
+++ b/_data/2020/princeton/location.yml
@@ -5,3 +5,4 @@ description: ""
 link: princeton
 year: 2020
 order: 99
+apply_button: hidden

--- a/_data/2020/tokyo/location.yml
+++ b/_data/2020/tokyo/location.yml
@@ -5,3 +5,4 @@ description: ""
 link: tokyo
 year: 2020
 order: 99
+apply_button: hidden

--- a/_includes/apply_list_group.html
+++ b/_includes/apply_list_group.html
@@ -1,11 +1,14 @@
+{% assign current_year_str = site.current_year | downcase %}
 {% for year in locations_by_year %}
-  <ul>
-    {% for year_location in year.locations %}
-      {% assign apply_data = year_location.apply %}
-      {% assign location_data = year_location.location %}
-      {% if apply_data.title %}
-        <li><a href={{site.baseurl}}/{{location_data.year}}/{{location_data.link}}/apply>{{location_data.title}}</a></li>
-      {% endif %}
-    {% endfor %}
-  </ul>
+  {% if current_year_str == year.year %}
+    <ul>
+      {% for year_location in year.locations %}
+        {% assign apply_data = year_location.apply %}
+        {% assign location_data = year_location.location %}
+        {% if apply_data.title and location_data.apply_button != "hidden" %}
+          <li><a href={{site.baseurl}}/{{location_data.year}}/{{location_data.link}}/apply>{{location_data.title}}</a></li>
+        {% endif %}
+      {% endfor %}
+    </ul>
+  {% endif %}
 {% endfor %}

--- a/_includes/locations_listing.html
+++ b/_includes/locations_listing.html
@@ -1,30 +1,24 @@
-{% if include.location_data %}
-  {% assign data = location_data %}
-  {% assign apply = apply_data %}
-
-    {% if data.title %}
-      <div class="col-sm-6 mb-5">
-        <div class="card border-0" id="{{data.link}}_{{data.year}}">
-          {% if data.image %}
-            {% assign image_prefix = data.image | slice: 0, 4 %}
-            {% if image_prefix == "http" %}
-              {% assign image_url = data.image %}
-            {% else %}
-              {% assign image_url = data.image | prepend: site.baseurl %}
-            {% endif %}
-            <img class="card-img-top" src="{{image_url}}" alt="Find a location">
-            <div class="card-body">
-              <h5 class="card-title">{{data.title}}</h5>
-              <h6 class="card-subtitle mb-2 text-muted">{{data.subtitle}}</h6>
-              <p class="card-text">{{data.description}}</p>
-              <a href="{{site.baseurl}}/{{data.year}}/{{data.link}}" class="btn btn-dark btn-sm">Learn More</a>
-              {% if apply.title %}
-              <a href="{{site.baseurl}}/{{data.year}}/{{data.link}}/apply" class="btn btn-dark btn-sm">Apply</a>
-              {% endif %}
-            </div>
+{% if include.location_data and include.location_data.title %}
+  <div class="col-sm-6 mb-5">
+    <div class="card border-0" id="{{include.location_data.link}}_{{include.location_data.year}}">
+      {% if include.location_data.image %}
+        {% assign image_prefix = include.location_data.image | slice: 0, 4 %}
+        {% if image_prefix == "http" %}
+          {% assign image_url = include.location_data.image %}
+        {% else %}
+          {% assign image_url = include.location_data.image | prepend: site.baseurl %}
+        {% endif %}
+        <img class="card-img-top" src="{{image_url}}" alt="Find a location">
+        <div class="card-body">
+          <h5 class="card-title">{{include.location_data.title}}</h5>
+          <h6 class="card-subtitle mb-2 text-muted">{{include.location_data.subtitle}}</h6>
+          <p class="card-text">{{include.location_data.description}}</p>
+          <a href="{{site.baseurl}}/{{include.location_data.year}}/{{include.location_data.link}}" class="btn btn-dark btn-sm">Learn More</a>
+          {% if include.apply_data.title and include.location_data.apply_button != "hidden" %}
+          <a href="{{site.baseurl}}/{{include.location_data.year}}/{{include.location_data.link}}/apply" class="btn btn-dark btn-sm">Apply</a>
           {% endif %}
         </div>
-      </div>
-    {% endif %}
-
+      {% endif %}
+    </div>
+  </div>
 {% endif %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -14,7 +14,7 @@
           <a class="nav-link" href="{{nav.url}}">{{nav.name}}</a>
         </li>
       {% endfor %}
-      {% if year == '2020' %}
+      {% if site.current_year | downcase == year and site.data[year][location].location.apply_button != "hidden" %}
       <li class="nav-item">
         <a class="nav-link btn btn-dark d-xl-inline-flex mt-3 ml-3" href="apply">Apply</a>
       </li>
@@ -22,7 +22,7 @@
       {% endif %}
     </ul>
     <ul class="nav flex-column">
-      <a class="nav-link collapsed" onmouseover=""" style="cursor: pointer;" data-toggle="collapse" data-target="">Other Events:</a>
+      <a class="nav-link collapsed" onmouseover="" style="cursor: pointer;" data-toggle="collapse" data-target="">Other Events:</a>
       {% for year_num in (2017..site.current_year) reversed %}
         {% assign allyears = year_num | downcase %}
         {% for checkyear in allyears %}


### PR DESCRIPTION
By setting `apply_button: hidden` in `location.yml`, that location's Apply button will be hidden on the location list page, the global apply screen, and the sidebar for that location.

@msalganik I've done this for all the postponed locations.

Fixes #540 

Again, I'll merge immediately, but feel free to suggest changes.