### PR TITLE
Update Montreal schedule with pre-SICSS events

### DIFF
--- a/_data/2020/montreal/schedule.yml
+++ b/_data/2020/montreal/schedule.yml
@@ -1,3 +1,15 @@
+- date: 2020-06-1
+  name: "Pre-SICSS courses begin: Interaction with TA and organizer (Optional)"
+
+- date: 2020-06-8
+  name: Courses posted online
+  events:
+    - name: "Monday: Ethics"
+    - name: "Tuesday: Collecting Digital Trace Data"
+    - name: "Wednesday: Automated Text Analysis"
+    - name: "Thursday: Surveys in the Digital Age"
+    - name: "Friday: Machine Learning"
+    
 - date: 2020-06-15
   name: Introduction and Ethics
   events:


### PR DESCRIPTION
Using the starting date of each event rather than the range, because date ranges in the headers seem to cause errors.