### PR TITLE
Add ability to hide sidebar

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,3 +1,4 @@
+{% if page.sidebar != "hide" %}
 <!-- detail page sidebar -->
 {% if page.partner_site %}
 {% assign urlparts = page.url | split: "/" %}
@@ -163,4 +164,4 @@
   </ul>
 </div>
 {% endif %}
-
+{% endif %}

--- a/curriculum.md
+++ b/curriculum.md
@@ -2,6 +2,7 @@
 layout: curriculum
 title: Learning Materials
 subtitle: Open source teaching and learning resources for computational social science.
+sidebar: hide
 ---
 
 We provide state-of-the art training in a range of different areas in computational social science from ethics to text analysis and mass collaboration. Below you can find archives of all of the videos, slides, code, and teaching exercises used in 2019. These lectures assume a basic, working knowledge of the R language. If you do not yet know R, [this resource](https://education.rstudio.com/) is a great place to start. If you are a teacher, the source code for all of our teaching materials is available [here](https://github.com/compsocialscience/summer-institute/tree/master/2019/materials). Or, check out alternative curricula developed by organizers of SICSS partner sites [here](https://github.com/compsocialscience/summer-institute/blob/master/_data/alternative_curriculum.md) that include material in different software languages and for different types of audiences.


### PR DESCRIPTION
Hide sidebar for curriculum page for now.

Fixes #2052 

@msalganik this hides the sidebar for the curriculum page. Any page may use this same feature. To re-enable the sidebar for this page, we just need to remove the `sidebar: hide` that I added to `curriculum.md`.