### PR TITLE
Add probability sample lecture

### DIFF
--- a/_data/curriculum.yml
+++ b/_data/curriculum.yml
@@ -192,6 +192,15 @@
       sublinks:
         - link: "https://youtu.be/14r4h8j9VRI"
           text: "Video"
+        - link: "https://github.com/compsocialscience/summer-institute/blob/master/2019/materials/day4-surveys/01-survey-research-digital-age.pdf"
+          text: "Slides"
+  topic: Probability and non-probability sampling
+  events:
+    - name: "Probability and non-probability sampling"
+      video: "https://www.youtube.com/embed/9olwcCwxA9I" 
+      sublinks:
+        - link: "https://www.youtube.com/watch/9olwcCwxA9I"
+          text: "Video"
         - link: "https://github.com/compsocialscience/summer-institute/blob/master/2019/materials/day4-surveys/02-nonprobability-sampling.pdf"
           text: "Slides"
     - name: "Computer-administered interviews and wiki surveys"


### PR DESCRIPTION
This lecture was mistakenly omitted from the 2019 curriculum archive. I added the video and the slides. I also updated the link for the slides of the "Survey research in the digital age" slides, which was wrong.