### PR TITLE
Fixing a curriculum bug

### DIFF
--- a/_data/curriculum.yml
+++ b/_data/curriculum.yml
@@ -194,7 +194,6 @@
           text: "Video"
         - link: "https://github.com/compsocialscience/summer-institute/blob/master/2019/materials/day4-surveys/01-survey-research-digital-age.pdf"
           text: "Slides"
-  topic: Probability and non-probability sampling
   events:
     - name: "Probability and non-probability sampling"
       video: "https://www.youtube.com/embed/9olwcCwxA9I" 


### PR DESCRIPTION
I had repeated "topic: Surveys in the Digital Age" twice, and this caused the first lecture of that day to not appear.