### PR TITLE
Allow customization of sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Science. It is powered by [GitHub Pages](https://pages.github.com/),
   * [Default](#default)
   * [Home](#home)
 * [Navigation Links](#navigation-links)
+* [Sidebar](#sidebar)
+  * [Hiding the sidebar](#hiding-the-sidebar)
+  * [Customizing the sidebar](#customizing-the-sidebar)
 * [Adding Additional Pages](#adding-additional-pages)
 * [Homepage](#homepage)
 * [Adding a partner location](#adding-a-partner-location)
@@ -52,6 +55,34 @@ Curriculum example:
 ```
 
 Keep in mind that this `YAML` file controls both the generation of the sidebar and the video listing as well.
+
+# Sidebar
+
+By default, the sidebar links will be automatically generated for pages with
+a `layout` of: `people`, `locations`, or `host`. Additionally, if a page has
+set `partner_site`, then it will also have a sidebar automatically generated.
+
+## Hiding the sidebar
+
+You can hide the sidebar by adding the following to a page's front matter:
+```yaml
+sidebar: hide
+```
+
+## Customizing the sidebar
+
+You can also completely customize the sidebar updating the page's front
+matter to list the links for the sidebar:
+
+```yaml
+sidebar:
+  - name: "Link to anchor in current page"
+    url: "#anchor"
+  - name: "Link to another page"
+    url: "/summer-institute/curriculum"
+  - name: "Link to another site"
+    url: "https://www.allourideas.org/"
+```
 
 # Location specific pages
 

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,4 +1,15 @@
 {% if page.sidebar != "hide" %}
+{% if page.sidebar.first %}
+  <div class="col-md-4">
+    <ul class="nav flex-column">
+    {% for link in page.sidebar %}
+      <li class="nav-item">
+        <a class="nav-link" href="{{ link.url }}">{{ link.name }}</a>
+      </li>
+    {% endfor %}
+    </ul>
+  </div>
+{% else %}
 <!-- detail page sidebar -->
 {% if page.partner_site %}
 {% assign urlparts = page.url | split: "/" %}
@@ -62,37 +73,6 @@
     </ul>
     </li>
     {% endfor %}
-  </ul>
-{% endif %}
-
-
-<!-- curriculum sidebar -->
-{% if page.layout == 'curriculum' %}
-  <ul class="nav flex-column">
-    <li class="nav-item">
-      <a class="nav-link active" href="#overview">Overview</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#day_1">Introduction and Ethics</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#day_2">Collecting Digital Trace Data</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#day_3">Automated Text Analysis</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#day_4">Surveys in the Digital Age</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#day_5">Mass Collaboration</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#day_6">Experiments in the Digital Age</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="#bonus_lectures">Bonus Lectures by Leaders in the Field</a>
-    </li>
   </ul>
 {% endif %}
 
@@ -164,4 +144,5 @@
   </ul>
 </div>
 {% endif %}
-{% endif %}
+{% endif %}{% comment %} // sidebar is not array or hash {% endcomment %}
+{% endif %}{% comment %} // sidebar is not "hide" {% endcomment %}


### PR DESCRIPTION
> On the curriculum page (https://compsocialscience.github.io/summer-institute/curriculum), we currently have the videos for 2020 at the top and the videos from 2019 at the bottom. Chris and Matt would like to put links on the left sidebar of the page that would take the user to separate pages for archived 2019 and 2018 videos.

@ilundberg This pull request adds the ability for a page to customize the list of links that get displayed in its sidebar. I've updated the README to include a Sidebar section with details on how to customize those links. I think with that, you can extract the content that you want on different pages and then update the sidebar with links to those new pages. Let me know if you have questions about that.