### PR TITLE
Curriculum day-specific links

### DIFF
--- a/_data/curriculum.yml
+++ b/_data/curriculum.yml
@@ -1,5 +1,5 @@
 - day: Day 1
-  id: day_2020_1
+  id: day_1
   topic: "Introduction and Ethics"
   events:
     - name: "Introduction to Computational Social Science"
@@ -48,7 +48,7 @@
 
     
 - day: Day 2
-  id: day_2020_2
+  id: day_2
   topic: "Collecting Digital Trace Data"
   events:
     - name: "What is digital trace data?"

--- a/curriculum.md
+++ b/curriculum.md
@@ -3,6 +3,18 @@ layout: curriculum
 title: Learning Materials
 subtitle: Open source teaching and learning resources for computational social science.
 sidebar:
+  - name: "Day 1: Introduction and Ethics"
+    url: "#day_1"
+  - name: "Day 2: Collecting Digital Trace Data"
+    url: "#day_2"
+  - name: "Day 3: Automated Text Analysis"
+    url: "#day_3"
+  - name: "Day 4: Surveys in the Digital Age"
+    url: "#day_4"
+  - name: "Day 5: Mass Collaboration"
+    url: "#day_5"
+  - name: "Day 6: Experiments"
+    url: "#day_6"
   - name: "Visiting speakers"
     url: "https://www.youtube.com/playlist?list=PL9UNgBC7ODr4iBr8nspxJKmZY85OXG8a3"
   - name: "Materials from previous years"


### PR DESCRIPTION
I am attempting to put links in the sidebar of the curriculum page that go to the day-specific videos. These link to anchors on the page which I believe are defined by the id for each day.