### PR TITLE
Remove col-md-4 in curriculum.html for sidebar

### DIFF
--- a/_layouts/curriculum.html
+++ b/_layouts/curriculum.html
@@ -10,9 +10,10 @@
     {% include hero_secondary.html %}
     <div class="container">
       <div class="row">
-        <div class="col-md-4">
+        <!-- Commenting this out because it happens already within sidebar.html -->
+        <!-- <div class="col-md-4"> -->
           {% include sidebar.html %}
-        </div>
+        <!-- </div> -->
         <div class="col-md-8" id="overview">
           <h2 class="display-4">Overview</h2>
           {{content}}


### PR DESCRIPTION
The sidebar takes up 4 / 12 columns, but the links take up only 4 / 12 of the sidebar. I am trying to remove one of those so that the links can take the full 4/12 of the page.