### PR TITLE
Update festival.md

### DIFF
--- a/2020/festival.md
+++ b/2020/festival.md
@@ -12,7 +12,7 @@ __Time:__ Monday, June 22, 2020. 12-1pm EDT
 
 __Speakers:__ [Matti Nelimarkka](https://matti.mante.li/) (SICSS-Princeton 17), [Rochelle Terman](http://rochelleterman.com/) (SICSS-Princeton 17), and [Jae Yeon Kim](https://jaeyk.github.io/) (SICSS-Princeton 19)
 
-__Moderator:__ Matthew Salganik
+__Moderator:__ [Matthew Salganik](https://www.princeton.edu/~mjs3/) (SICSS-Princeton 17, SICSS-Duke 18, SICSS-Princeton 19, SICSS-Duke 20)
 
 __Description:__ Teaching computational social science at both the undergraduate and graduate level presents a number of challenging pedagogical questions. How should we teach a class with students from different disciplinary backgrounds?  What is the role of programming in computational social science education? How should computational social science courses fit into a larger curriculum?  The panelists will address these questions---and others---first in a moderated conversation and then will take questions from the audience.   
 
@@ -26,7 +26,7 @@ __Time:__ Tuesday, June 23, 2020. 3:30-4:30pm EDT
 
 __Speakers:__ [Taylor W. Brown](https://www.taylorwhittenbrown.com/) (SICSS-Princeton 17, SICSS-Duke 18, SICSS-Oxford 19), [Naniette H. Coleman](https://www.naniettecoleman.com/) (SICSS-Princeton 19), and [Tina Law](https://tinalaw1.github.io/) (SICSS-Duke 18)
 
-__Moderator:__ Matthew Salganik
+__Moderator:__ [Matthew Salganik](https://www.princeton.edu/~mjs3/) (SICSS-Princeton 17, SICSS-Duke 18, SICSS-Princeton 19, SICSS-Duke 20)
 
 __Description:__ In order to thrive, the field of computational social science requires contributions from people from different intellectual backgrounds and different life experiences. The panelists will discuss their own efforts to increase diversity in computational social science, describe why they think this work is important, explain what other efforts are underway now, and what they think should be done in the future.  There will also be time for the audience to submit written questions to be asked by the moderator.
 
@@ -36,11 +36,11 @@ __Archiving:__ This talk will be recorded and archived.
 
 ## Using Empirica for high-throughput virtual lab experiments
 
-__Time:__ Wednesday, June 24, 2020. 1-2:30pm EDT
+__Time:__ Two sessions. Wednesday, June 24, 2020. 1-2:30pm EDT and Friday, June 26, 2020. 10-11:30am EDT.
 
-__Speakers:__ [Abdullah Almaatouq](http://www.amaatouq.com/) (SICSS-Princeton 17), [James Houghton](http://www.jamesphoughton.com/) (SICSS-Duke 20), and Nicolas Paton.
+__Speakers:__ [Abdullah Almaatouq](http://www.amaatouq.com/) (SICSS-Princeton 17), [Joshua Becker](https://www.joshua-becker.com/) (SICSS-Princeton 17), [James Houghton](http://www.jamesphoughton.com/) (SICSS-Duke 20), Nicolas Paton.
 
-__Description:__ [Empirica](https://empirica.ly/) is a new open source software platform for developing and conducting synchronous and interactive human-subject experiments.  It has already been used by researchers around the world. This session will start with a live demonstration where participants will take part in a real-time experiment involving dozens of people.  Next, the data from that experiment will be downloaded and analyzed.  Thus, participants will have a behind-the-scenes, end-to-end experience with an experiment run with Emprica. Finally, there will be time for questions and discussion about Empirica and the future of experiments in the social sciences.
+__Description:__ [Empirica](https://empirica.ly/) is a new open source software platform for developing and conducting synchronous and interactive human-subject experiments.  It has already been used by researchers around the world. This session will start with a live demonstration where participants will take part in a real-time experiment involving dozens of people.  Next, the data from that experiment will be downloaded and analyzed.  Thus, participants will have a behind-the-scenes, end-to-end experience with an experiment run with Emprica. Finally, there will be time for questions and discussion about Empirica and the future of experiments in the social sciences. **This session is targeted toward beginner users.** See Friday for an advanced session.
 
 __Open to:__ Up to 30 registered participants: [Registration form](https://forms.gle/eziGBbMQE4VxP1tT9)
 
@@ -48,13 +48,42 @@ __Preparatory materials:__ All registered participants are strongly encouraged t
 
 __Archiving:__ This talk will be recorded and archived.
 
+## Computational social science to address the (post) COVID-19 reality
+
+__Time:__ Wednesday, June 24, 2020, 10–11:15am EDT
+
+__Speakers:__ [Johan Bollen](https://homes.luddy.indiana.edu/jbollen/) [Dean Eckles](https://www.deaneckles.com/)
+
+__Moderators:__ [Mark Cliffe](https://think.ing.com/author/mark-cliffe/), [Monika Leszczynska](https://empiricalcontracts.com/) (SICSS-Princeton 19, SICSS-Maastricht 20)
+
+__Description:__ Computational Social Science offers tools that can assist both policy makers and the private sector in the design and implementation of measures to address the economic and social challenges posed by COVID-19. How can the growing sources of (alternative) data and data science be used in a meaningful and responsible way, i.e. providing reliable and practical knowledge without compromising privacy and safety of people whose data is collected and analyzed? What are the methodological and regulatory solutions that could be applied to address the challenges and mitigate the risks? Our panelists will share their experience and ideas on these issues. There will also be enough time for questions from the audience.
+
+Co-organized with the [Maastricht Law and Tech Lab](https://www.maastrichtuniversity.nl/about-um/faculties/law/research/law-and-tech-lab), [ING](https://www.ing.com/), and the [Think Forward Initiative](https://www.thinkforwardinitiative.com/)
+
+__Open to:__ Unlimited registered participants: [Registration form](https://legal.typeform.com/to/ZOb9SY)
+
+__Archiving:__ This talk will be recorded and archived.
+
+## Panel discussion on digital and computational demography
+
+__Time:__ Wednesday, June 24, 2020. Time coming soon.
+
+__Speakers:__ [Vissého Adjiwanou]() (SICSS-Princeton 17, SICSS-Cape Town 18, SICSS-Cape Town 19, SICSS-Montreal 20), [Nicolò Cavalli] (https://www.sociology.ox.ac.uk/graduate/nicolo-cavalli.html) (SICSS-Duke 18, SICSS-Oxford 19), [Ridhi Kashyap](https://www.nuffield.ox.ac.uk/people/profiles/ridhi-kashyap/) (SICSS-Princeton 17, SICSS-Oxford 19),  [Francesco Rampazzo](https://francescorampazzo.com/) (SICSS-Duke 18)
+
+__Description:__ Coming soon.
+
+__Open to:__ Coming soon.
+
+__Archiving:__ Coming soon.
+
+
 ## Creating open source software as part of an academic career
 
 __Time:__ Thursday, June 25, 2020. 11am-12pm EDT
 
 __Speakers:__ [Ryan Gallagher](https://ryanjgallagher.github.io/) (SICSS-Duke 18), [Anne Helby Petersen](https://biostat.ku.dk/staff_/?pure=en/persons/395810) (SICSS-Duke 18), and [Carsten Schwemmer](https://www.carstenschwemmer.com/) (SICSS-Duke 18)
 
-__Moderator:__ Matthew Salganik
+__Moderator:__ [Matthew Salganik](https://www.princeton.edu/~mjs3/) (SICSS-Princeton 17, SICSS-Duke 18, SICSS-Princeton 19, SICSS-Duke 20)
 
 __Description:__ Almost all computational social science depends on open source software, yet very few computational social scientists actually contribute to open source software.  These panelists will share their experiences developing open source software as part of an academic career, and they will offer advice for others who want to contribute to existing open source projects or start new ones.  There will be time for questions from the audience.
 
@@ -62,14 +91,13 @@ __Open to:__ Unlimited registered participants: [Registration form](https://form
 
 __Archiving:__ This talk will be recorded and archived.
 
-
 ## Opportunities and challenges with industry collaborations
 
 __Time:__ Friday, June 26, 2020. 10-11am EDT
 
 __Speakers:__ [Dave Holtz](https://www.daveholtz.net/) (SICSS-Duke 18) and [Sanaz Mobasseri](https://www.sanazmobasseri.com/) (SICSS-Duke 18)
 
-__Moderator:__ Matthew Salganik
+__Moderator:__ [Matthew Salganik](https://www.princeton.edu/~mjs3/) (SICSS-Princeton 17, SICSS-Duke 18, SICSS-Princeton 19, SICSS-Duke 20)
 
 __Description:__ Most big data sources are controlled by companies, and many computational social scientists struggle to get access to these data. These panelists, who have experience collaborating with companies on research projects, will share insights about initiating, developing, and maintaining productive collaborations between researchers and companies. They will discuss practical issues, such as negotiating data usage agreements and navigating legal considerations for both parties, as well as describe potential risks and ethical issues created by these collaborations. There will be time for questions from the audience.
 


### PR DESCRIPTION
Updated Matthew Salganik's name to have the website link and SICSS affiliations. Added Joshua Becker to the Empirica event speaker list. Added a placeholder for the digital and computational demography session.