### PR TITLE
Update link for regex cheatsheet

### DIFF
--- a/2020/materials/day3-text-analysis/basic-text-analysis/rmarkdown/Basic_Text_Analysis_in_R.Rmd
+++ b/2020/materials/day3-text-analysis/basic-text-analysis/rmarkdown/Basic_Text_Analysis_in_R.Rmd
@@ -71,7 +71,7 @@ some_text<-c("Friends","don'tt","let","friends","make","wordclouds")
 some_text[grep("^[F]", some_text)]
 ```
 
-[Here](http://www.rstudio.com/wp-content/uploads/2016/09/RegExCheatsheet.pdf) is a useful cheatsheet that includes more examples of how to use GREP to find patterns in text.
+[Here](https://github.com/rstudio/cheatsheets/blob/master/regex.pdf) is a useful cheatsheet that includes more examples of how to use GREP to find patterns in text.
 
 GREP commands are fairly straight forward, and much more powerful and useful for subsetting rows or columns within larger datasets. There is one more concept which is important for you to grasp about GREP, however, which is that certain characters such as `"` confuse the techniques. For example
 


### PR DESCRIPTION
Hi @cbail, I'm watching the [pre-arrival materials](https://sicss.io/2021/fgv-dapp-brazil/pre_arrival) and noticed that there is a link that is no longer available. I updated the link, found the cheat sheet at the Rstudio repository of cheatsheets.

I added the link to the GitHub page of the file but is also possible to use this direct link: https://github.com/rstudio/cheatsheets/raw/master/regex.pdf (but in my case, the link downloads the cheatsheet, and I don't know if is the best choice)

Thanks for the awesome classes!

