### PR TITLE
feat: fix things, add schedule

### DIFF
--- a/_data/2023/ias/faculty.yml
+++ b/_data/2023/ias/faculty.yml
@@ -5,7 +5,7 @@
 
 - name: Carl Nordlund
   image: /assets/images/ias_carl_nordlund.jpg
-  bio: Carl Nordlund is an associate professor (docent) at the Institute for Analytical Sociology at Linköping University. Following studies in computer science, mathematics, economic history, development studies and human ecology, he obtained his PhD in human ecology from the Department of Human Geography at Lund University in 2010. This was followed by postdoctoral fellowships at Central European University, Budapest, with joint positions at the Department of Political Science and Center for Network Science, and positions at the European University Institute, Florence, and Department of Economic History, Lund University. His work has mainly been published in Social Networks, as well as Network Science, Geographical Analysis, Journal of European Integration, and Studies in Comparative International Development. In addition to project management tasks, his substantive interests within this project is in inter-ethnic family formation and labor market structures, as well as the development of network-analytical methods, particularly deterministic blockmodeling techniques, and in D3js visualization techniques.
+  bio: Carl Nordlund is an associate professor (docent) at the Institute for Analytical Sociology at Linköping University. Obtaining a PhD in human ecology from Lund University in 2010, this was followed by fellowships in Budapest, Florence, and Lund, before starting at IAS in 2018. His substantive interests is in inter-ethnic family formation and labor market structures, economic globalization, as well as the development of network-analytical methods, particularly deterministic blockmodeling methods.
   website: https://demesta.com/
 
 - name: Anastasia Menshikova
@@ -29,6 +29,6 @@
   website: https://liu.se/en/employee/alero03
   
 - name: Maël Lecoursonnais
-  image: /assets/images/mael_lecoursonnais.jpeg
+  image: /assets/images/mael_lecoursonnais.jpg
   bio: Maël Lecoursonnais is a PhD student at the Institute for Analytical Sociology. His research interests span spatial inequalities, causal inference, and applied machine learning. His current project investigates the consequences of spatial inequalities on life-course outcomes such as education or income, using causally-oriented methods and/or machine learning algorithms. 
   website: https://maellecoursonnais.github.io/

--- a/_data/2023/ias/schedule.yml
+++ b/_data/2023/ias/schedule.yml
@@ -1,3 +1,85 @@
-- date: June 12, 2023
+- date: 2023-06-11 # Sunday
+  name: Arrival
   events:
-    - name: "Schedule coming soon..."
+    - name: "15:00 - 18:00 Check in at Hotel"
+    - name: "18:00 - 20:00 Welcome Meet up"
+
+- date: 2023-06-12 # Monday
+  name: Introduction and Ethics
+  events:
+    - name: "09:30 - 10:00 Introduction and Welcome (Jacob Habinek)" 
+    - name: "10:00 - 12:00 Lecture: Computational Social Science (Jacob Habinek)" 
+    - name: "12:00 - 13:00 Lunch Break"
+    - name: "13:00 - 15:00 Workshop: Ethics (Elis Carlberg Larsson)"
+    - name: "15:00 - 16:00 Fika Break"
+    - name: "18:00 - 20:00 Welcome Dinner"
+
+- date: 2023-06-13 # Tuesday
+  name: Digital Trace Data
+  events:
+    - name: "10:00 - 12:00 Lecture: Digital Trace Data (Anastasia Menshikova)"
+    - name: "12:00 - 13:00 Lunch Break"
+    - name: "13:00 - 15:00 Workshop: Collecting Digital Data (Anastasia Menshikova and Maël Lecoursonnais)"
+    - name: "15:00 - 16:00 Fika Break"
+    - name: "16:00 - 17:30 Research Talk (TBA)"
+
+- date: 2023-06-14 # Wednesday
+  name: Computational Text Analysis
+  events:
+    - name: "10:00 - 12:00 Lecture: Computational Text Analysis (Hendrik Erz)"
+    - name: "12:00 - 13:00 Lunch Break"
+    - name: "13:00 - 15:00 Workshop: Computational Text Analysis (Hendrik Erz and Maël Lecoursonnais)"
+    - name: "15:00 - 16:00 Fika Break"
+
+- date: 2023-06-15 # Thursday
+  name: Social Network Analysis
+  events:
+    - name: "09:30 - 11:30 Lecture: Social Network Analysis (Carl Nordlund)"
+    - name: "11:30 - 12:30 Lunch Break"
+    - name: "12:30 - 14:30 Workshop: Social Network Analysis (Alexandra Rottenkolber)"
+    - name: "14:30 - 16:00 Research Talk: How Should an Employee Be?: The Literature of Business Self-Help and the Construction of Financialized Subjects (Carly Knight)"
+    - name: "16:00 - 17:00 Fika Break"
+
+- date: 2023-06-16 # Friday
+  name: Spatial Data
+  events:
+    - name: "10:00 - 12:00 Workshop: Spatial Data (Maël Lecoursonnais)"
+    - name: "12:00 - 13:00 Lunch Break"
+    - name: "13:00 - 15:00 Matchmaking for the Group Projects"
+    - name: "15:00 - 16:00 Fika Break"
+
+- date: 2023-06-17 # Saturday
+  name: Weekend day off
+
+- date: 2023-06-18 # Sunday
+  name: Weekend day off
+
+- date: 2023-06-19 # Monday
+  name: Project Week
+  events:
+    - name: "10:00 - 17:00 Project Working Time"
+
+- date: 2023-06-20 # Tuesday
+  name: Project Week
+  events:
+    - name: "10:00 - 16:00 Project Working Time"
+    - name: "16:00 - 17:30 Research Talk (TBA)"
+
+- date: 2023-06-21 # Wednesday
+  name: Project Week
+  events:
+    - name: "10:00 - 17:00 Project Working Time"
+
+- date: 2023-06-22 # Thursday
+  name: Final Day
+  events:
+    - name: "10:00 - 12:00 Project Working Time"
+    - name: "12:00 - 13:00 Lunch Break"
+    - name: "13:00 - 16:00 Project Presentations"
+    - name: "16:00 - 17:00 Fika Break"
+    - name: "18:00 - 20:00 Farewell Dinner"
+
+- date: 2023-06-23 # Friday
+  name: Swedish Midsummer
+  events:
+    - name: "11:00-15.00 Midsummer Picnic (optional)"


### PR DESCRIPTION
This second PR adds the preliminary schedule for the IAS 2023 Norrköping instance of SICSS. It also fixes a broken link and adapts an overly long bio.