### PR TITLE
SICSS-23: Add location filter for learning materials/video page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,6 +57,8 @@ video_listing:
         python: Python
         rust: Rust
         javascript: JavaScript
+    - name: Location
+      key: location
     - name: Authors
       key: author
 


### PR DESCRIPTION
This PR adds the location filter in the learning materials/video page to show videos by location.