### PR TITLE
SICSS-27: Post-Mortems page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -10,7 +10,9 @@
   url: "/people"
 - name: About
   url: "/about"
-- name: News
+- name: Post-Mortem
+  url: "/post-mortem"
+- name: In the News
   url: "/in-the-news" 
 - name: Festival
   url: "/festival"

--- a/_layouts/post-mortem.html
+++ b/_layouts/post-mortem.html
@@ -22,7 +22,7 @@
             locations_with_post_mortems=true %} {% endif %} {% endfor %} {% if
             locations_with_post_mortems %}
             <ul
-              class="btn-collapse-toggle"
+              class="btn-collapse-toggle collapsed"
               type="button"
               data-toggle="collapse"
               data-target="#collapse{{forloop.index}}"
@@ -31,10 +31,15 @@
               id="post-mortem-year"
             >
               {{year.year}}
+              <span class="collapse-caret"></span>
             </ul>
             {%else%}
-            <ul id="post-mortem-year-deactivated">
+            <ul
+              class="btn-collapse-toggle collapsed"
+              id="post-mortem-year-deactivated"
+            >
               {{year.year}}
+              <span class="collapse-caret"></span>
             </ul>
             {%endif%}
             <div

--- a/_layouts/post-mortem.html
+++ b/_layouts/post-mortem.html
@@ -1,0 +1,59 @@
+{% include setup_data.html %}
+<!-- {% include setup_locations_by_year.inc %} -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    {% include header.html %}
+  </head>
+
+  <body class="sub-page">
+    {% include navbar.html %} {% include hero_secondary.html %}
+    <!-- Start content -->
+    <section>
+      <div class="container">
+        <h2 class="display-4 text-center">Post-Mortems</h2>
+        <div class="accordion" id="accordionMenu">
+          {% for year in locations_by_year %}
+          <div class="card">
+            <div class="card-header">
+              <h2 class="mb-0">
+                <ul
+                  class="align-middle"
+                  type="button"
+                  data-toggle="collapse"
+                  data-target="#collapse{{forloop.index}}"
+                  aria-expanded="true"
+                  aria-controls="collapseOne"
+                >
+                  {{year.year}}
+                </ul>
+                <div
+                  class="nav collapse"
+                  id="collapse{{forloop.index}}"
+                  aria-labelledby="{{forloop.index}}"
+                  data-parent="#accordionMenu"
+                >
+                  {% for year_location in year.locations %} {% assign campus =
+                  year_location.location %} {% assign post_mortem =
+                  year_location.post_mortem[0] %} {% if campus.title %} {% if
+                  post_mortem.title %}
+                  <li class="nav-item w-100">
+                    <a
+                      class="nav-link"
+                      href="{{site.baseurl}}/{{campus.year}}/post-mortem#{{campus.link}}"
+                    >
+                      {{campus.title}} {{post_mortem.title}}
+                    </a>
+                  </li>
+                  {% endif %} {% endif %} {% endfor %}
+                </div>
+              </h2>
+            </div>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+    </section>
+    {% include footer.html %}
+  </body>
+</html>

--- a/_layouts/post-mortem.html
+++ b/_layouts/post-mortem.html
@@ -6,16 +6,21 @@
     {% include header.html %}
   </head>
 
+  {% comment %} {{ year.locations | find:"post_mortem" }} {% endcomment %}
+
   <body class="sub-page">
-    {% include navbar.html %} {% include hero_secondary.html %} {% include
-    breadcrumb.html %}
+    {% include navbar.html %} {% include hero_secondary.html %}
     <!-- Start content -->
     <section>
       <div class="container default">
         <h2 class="display-4">Post-Mortems</h2>
         <div class="accordion" id="accordionMenu">
           {% for year in locations_by_year %}
-          <div id="postMortemContainer">
+          <div id="post-mortem-container">
+            {% assign locations_with_post_mortems=false %} {% for year_location
+            in year.locations %} {% if year_location.post_mortem[0] %} {% assign
+            locations_with_post_mortems=true %} {% endif %} {% endfor %} {% if
+            locations_with_post_mortems %}
             <ul
               class="btn-collapse-toggle"
               type="button"
@@ -23,10 +28,15 @@
               data-target="#collapse{{forloop.index}}"
               aria-expanded="false"
               aria-controls="collapse{{forloop.index}}"
-              id="postMortemYear"
+              id="post-mortem-year"
             >
               {{year.year}}
             </ul>
+            {%else%}
+            <ul id="post-mortem-year-deactivated">
+              {{year.year}}
+            </ul>
+            {%endif%}
             <div
               class="nav collapse"
               id="collapse{{forloop.index}}"
@@ -40,13 +50,13 @@
               <li class="nav-item w-100">
                 <a
                   class="nav-link"
-                  id="postMortemItems"
+                  id="post-mortem-item"
                   href="{{site.baseurl}}/{{campus.year}}/post-mortem#{{campus.link}}"
                 >
                   {{campus.title}} {{post_mortem.title}}
                 </a>
               </li>
-              <hr id="postMortemBreak" />
+              <hr id="post-mortem-break" />
               {% endif %} {% endif %} {% endfor %}
             </div>
           </div>

--- a/_layouts/post-mortem.html
+++ b/_layouts/post-mortem.html
@@ -7,21 +7,22 @@
   </head>
 
   <body class="sub-page">
-    {% include navbar.html %} {% include hero_secondary.html %}
+    {% include navbar.html %} {% include hero_secondary.html %} {% include
+    breadcrumb.html %}
     <!-- Start content -->
     <section>
-      <div class="container">
-        <h2 class="display-4 text-center">Post-Mortems</h2>
+      <div class="container default">
+        <h2 class="display-4">Post-Mortems</h2>
         <div class="accordion" id="accordionMenu">
           {% for year in locations_by_year %}
           <div id="postMortemContainer">
             <ul
-              class="align-middle"
+              class="btn-collapse-toggle"
               type="button"
               data-toggle="collapse"
               data-target="#collapse{{forloop.index}}"
-              aria-expanded="true"
-              aria-controls="collapseOne"
+              aria-expanded="false"
+              aria-controls="collapse{{forloop.index}}"
               id="postMortemYear"
             >
               {{year.year}}

--- a/_layouts/post-mortem.html
+++ b/_layouts/post-mortem.html
@@ -14,40 +14,39 @@
         <h2 class="display-4 text-center">Post-Mortems</h2>
         <div class="accordion" id="accordionMenu">
           {% for year in locations_by_year %}
-          <div class="card">
-            <div class="card-header">
-              <h2 class="mb-0">
-                <ul
-                  class="align-middle"
-                  type="button"
-                  data-toggle="collapse"
-                  data-target="#collapse{{forloop.index}}"
-                  aria-expanded="true"
-                  aria-controls="collapseOne"
+          <div id="postMortemContainer">
+            <ul
+              class="align-middle"
+              type="button"
+              data-toggle="collapse"
+              data-target="#collapse{{forloop.index}}"
+              aria-expanded="true"
+              aria-controls="collapseOne"
+              id="postMortemYear"
+            >
+              {{year.year}}
+            </ul>
+            <div
+              class="nav collapse"
+              id="collapse{{forloop.index}}"
+              aria-labelledby="{{forloop.index}}"
+              data-parent="#accordionMenu"
+            >
+              {% for year_location in year.locations %} {% assign campus =
+              year_location.location %} {% assign post_mortem =
+              year_location.post_mortem[0] %} {% if campus.title %} {% if
+              post_mortem.title %}
+              <li class="nav-item w-100">
+                <a
+                  class="nav-link"
+                  id="postMortemItems"
+                  href="{{site.baseurl}}/{{campus.year}}/post-mortem#{{campus.link}}"
                 >
-                  {{year.year}}
-                </ul>
-                <div
-                  class="nav collapse"
-                  id="collapse{{forloop.index}}"
-                  aria-labelledby="{{forloop.index}}"
-                  data-parent="#accordionMenu"
-                >
-                  {% for year_location in year.locations %} {% assign campus =
-                  year_location.location %} {% assign post_mortem =
-                  year_location.post_mortem[0] %} {% if campus.title %} {% if
-                  post_mortem.title %}
-                  <li class="nav-item w-100">
-                    <a
-                      class="nav-link"
-                      href="{{site.baseurl}}/{{campus.year}}/post-mortem#{{campus.link}}"
-                    >
-                      {{campus.title}} {{post_mortem.title}}
-                    </a>
-                  </li>
-                  {% endif %} {% endif %} {% endfor %}
-                </div>
-              </h2>
+                  {{campus.title}} {{post_mortem.title}}
+                </a>
+              </li>
+              <hr id="postMortemBreak" />
+              {% endif %} {% endif %} {% endfor %}
             </div>
           </div>
           {% endfor %}

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -175,7 +175,7 @@ figure figcaption {
   display: block;
 }
 
-#postMortemContainer {
+#post-mortem-container {
   display: flex;
   min-width: 336px;
   max-width: 991px;
@@ -184,8 +184,7 @@ figure figcaption {
   gap: 30px;
   align-self: stretch;
 }
-
-#postMortemYear {
+#post-mortem-year {
   display: flex;
   padding: 10px 16px;
   justify-content: space-between;
@@ -195,8 +194,19 @@ figure figcaption {
   border: 0.5px solid #343A40;
   background: #FFF;
 }
-
-#postMortemItems {
+#post-mortem-year-deactivated {
+  display: flex;
+  padding: 10px 16px;
+  justify-content: space-between;
+  align-items: center;
+  align-self: stretch;
+  border-radius: 4px;
+  border: 0.5px solid #343A40;
+  background: #FFF;
+  color: #d3d3d3;
+  pointer-events: none;
+}
+#post-mortem-item {
   display: flex;
   padding: 0px 20px;
   flex-direction: column;
@@ -204,8 +214,7 @@ figure figcaption {
   gap: 10px;
   align-self: stretch;
 }
-
-#postMortemBreak {
+#post-mortem-break {
   width: 100%;
   background: rgba(52, 58, 64, 0.50);
 }

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -9,6 +9,9 @@ body {
   background: #f1f1f1;
   font-family: "Roboto", sans-serif;
 }
+a {
+  color: #005EC2;
+}
 .jumbotron {
   background-image: url("../images/hero-accent.jpg");
   background-repeat: no-repeat;
@@ -37,7 +40,7 @@ body {
 }
 .nav .active {
   background: rgba(255, 255, 255, 0.75);
-  color: #005ec4;
+  color: #005EC2;
   display: inline-flex;
   border-radius: 4px;
 }

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -174,3 +174,40 @@ figure figcaption {
 #video-listing-container.no-video-results #video-search-no-matches {
   display: block;
 }
+
+#postMortemContainer {
+  display: flex;
+  min-width: 336px;
+  max-width: 991px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 30px;
+  align-self: stretch;
+}
+
+#postMortemYear {
+  display: flex;
+  padding: 10px 16px;
+  justify-content: space-between;
+  align-items: center;
+  align-self: stretch;
+  border-radius: 4px;
+  border: 0.5px solid #343A40;
+  background: #FFF;
+}
+
+#postMortemItems {
+  display: flex;
+  padding: 0px 20px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+  align-self: stretch;
+}
+
+#postMortemBreak {
+  width: 100%;
+  background: rgba(52, 58, 64, 0.50);
+}
+
+

--- a/in-the-news.md
+++ b/in-the-news.md
@@ -1,7 +1,7 @@
 ---
 title: ""
 subtitle: ""
-layout: about
+layout: page
 ---
 
 <h2 class="display-4">SICSS In The News </h2>

--- a/post-mortem.md
+++ b/post-mortem.md
@@ -1,0 +1,5 @@
+---
+layout: post-mortem
+title: ""
+subtitle: ""
+---


### PR DESCRIPTION
https://agathongroup.atlassian.net/browse/SICSS-27

This PR separates post-mortems from the "In the News" page into its own separate page with an accordion menu to separate years. In addition, it changes the blue link color to a more accessibility-friendly one.

![Screenshot 2023-09-01 at 5 33 55 PM](https://github.com/compsocialscience/summer-institute/assets/18548300/b5f181bd-4e30-4a61-a87d-d32d1ffaf3d7)
