### PR TITLE
SICSS-27: In the News

### DIFF
--- a/_layouts/in-the-news.html
+++ b/_layouts/in-the-news.html
@@ -1,0 +1,416 @@
+{% include setup_data.html %}
+<!-- {% include setup_locations_by_year.inc %} -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    {% include header.html %}
+  </head>
+
+  <body class="sub-page">
+    {% include navbar.html %} {% include hero_secondary.html %}
+    <!-- Start content -->
+    <section>
+      <div class="container default">
+        <h2 class="page-title">SICSS - IN THE NEWS</h2>
+        <div id="in-the-news-container">
+          <section style="width: 100%">
+            <div id="in-the-news-year-container">
+              <p id="in-the-news-year">2023</p>
+              <span id="in-the-news-line"></span>
+            </div>
+
+            <div class="card mb-2">
+              <div class="card-body" style="justify-content: space-around">
+                <a
+                  class="card-title"
+                  id="in-the-news-article-title"
+                  href="https://news.syr.edu/blog/2023/03/16/newhouse-postdoctoral-scholar-to-co-lead-summer-institute/"
+                  target="_blank"
+                >
+                  Newhouse Postdoctoral Scholar to Co-Lead Summer Institute
+                </a>
+                <p class="my-2" id="in-the-news-subtitle">
+                  Posted By: Syracuse University News
+                </p>
+                <p id="in-the-news-date">March 16, 2023</p>
+              </div>
+            </div>
+          </section>
+
+          <section style="width: 100%">
+            <div id="in-the-news-year-container">
+              <p id="in-the-news-year">2022</p>
+              <span id="in-the-news-line"></span>
+            </div>
+
+            <div class="card mb-2">
+              <div class="card-body" style="justify-content: space-around">
+                <a
+                  class="card-title"
+                  id="in-the-news-article-title"
+                  href="https://dukemag.duke.edu/stories/unsocial-media"
+                  target="_blank"
+                >
+                  Unsocial Media: Sociologist Chris Bail calls for a reset of
+                  our partisan digital divide
+                </a>
+                <p class="my-2" id="in-the-news-subtitle">
+                  Posted By: Duke Magazine
+                </p>
+                <p id="in-the-news-date">December 01, 2022</p>
+              </div>
+            </div>
+            <div class="card mb-2">
+              <div class="card-body" style="justify-content: space-around">
+                <a
+                  class="card-title"
+                  id="in-the-news-article-title"
+                  href="https://www.kdischool.ac.kr/gallery.es?mid=a30101000000&bid=0003&list_no=17607&act=view"
+                  target="_blank"
+                >
+                  KDI School and KAIST organized the first Summer Institute in
+                  Computational Social Science (SICSS) in Korea
+                </a>
+                <p class="my-2" id="in-the-news-subtitle">
+                  Posted By: KDI School of Public Policy and Management News
+                  Center
+                </p>
+                <p id="in-the-news-date">September 27, 2022</p>
+              </div>
+            </div>
+            <div class="card mb-2">
+              <div class="card-body" style="justify-content: space-around">
+                <a
+                  class="card-title"
+                  id="in-the-news-article-title"
+                  href="https://www.digitalottomanstudies.com/post/summerschool"
+                  target="_blank"
+                >
+                  My Notes on Summer School in Computational Social Sciences
+                </a>
+                <p class="my-2" id="in-the-news-subtitle">
+                  Posted By: Digital Ottoman Studies
+                </p>
+                <p id="in-the-news-date">December 19, 2022</p>
+              </div>
+            </div>
+            <div class="card mb-2">
+              <div class="card-body" style="justify-content: space-around">
+                <a
+                  class="card-title"
+                  id="in-the-news-article-title"
+                  href="https://www.sydney.edu.au/arts/news-and-events/news/2022/06/23/what-is-computational-social-science.html"
+                  target="_blank"
+                >
+                  What is computational social science? How social science
+                  researchers are using big data to understand human behavior at
+                  scale
+                </a>
+                <p class="my-2" id="in-the-news-subtitle">
+                  Posted By: University of Sydney News
+                </p>
+                <p id="in-the-news-date">June 23, 2022</p>
+              </div>
+            </div>
+            <div class="card mb-2">
+              <div class="card-body" style="justify-content: space-around">
+                <a
+                  class="card-title"
+                  id="in-the-news-article-title"
+                  href="https://portal.fgv.br/en/news/fgv-holds-second-brazilian-edition-summer-institute-computational-social-science"
+                  target="_blank"
+                >
+                  FGV holds the second Brazilian edition of the Summer Institute
+                  in Computational Social Science
+                </a>
+                <p class="my-2" id="in-the-news-subtitle">Posted By: FGV</p>
+                <p id="in-the-news-date">March 25, 2022</p>
+              </div>
+            </div>
+            <div class="card mb-2">
+              <div class="card-body" style="justify-content: space-around">
+                <a
+                  class="card-title"
+                  id="in-the-news-article-title"
+                  href="https://jurnal.republika.co.id/posts/167064/pertama-di-indonesia-fti-uii-gelar-sicss-jogja-2022"
+                  target="_blank"
+                >
+                  The first in Indonesia, UII was selected for the 2022 SICSS
+                  title [Indonesian]
+                </a>
+                <p class="my-2" id="in-the-news-subtitle">
+                  Posted By: Republika Online
+                </p>
+                <p id="in-the-news-date">July 22, 2022</p>
+              </div>
+            </div>
+            <div class="card mb-2">
+              <div class="card-body" style="justify-content: space-around">
+                <a
+                  class="card-title"
+                  id="in-the-news-article-title"
+                  href="https://www.jogpaper.net/sicss-cara-baru-mengolah-big-data-bidang-ilmu-sosial/"
+                  target="_blank"
+                >
+                  A new way to process big data in the field of social sciences
+                  [Indonesian]
+                </a>
+                <p class="my-2" id="in-the-news-subtitle">
+                  Posted By: Jogpaper.net
+                </p>
+                <p id="in-the-news-date">July 23, 2022</p>
+              </div>
+            </div>
+            <div class="card mb-2">
+              <div class="card-body" style="justify-content: space-around">
+                <a
+                  class="card-title"
+                  id="in-the-news-article-title"
+                  href="https://magazine.howard.edu/stories/beyond-the-numbers"
+                  target="_blank"
+                >
+                  Beyond the Numbers - Howard is Preparing to Educate the Next
+                  Generation of Black Data Scientists
+                </a>
+                <p class="my-2" id="in-the-news-subtitle">
+                  Posted By: Howard Magazine
+                </p>
+                <p id="in-the-news-date">June 21, 2022</p>
+              </div>
+            </div>
+            <div class="card mb-2">
+              <div class="card-body" style="justify-content: space-around">
+                <a
+                  class="card-title"
+                  id="in-the-news-article-title"
+                  href="https://www.washingtonpost.com/business/2022/06/22/women-scientists-authorship-credit-study/"
+                  target="_blank"
+                >
+                  Female scientists don't get the credit they deserve. A study
+                  proves it
+                </a>
+                <p class="my-2" id="in-the-news-subtitle">
+                  Posted By: The Washington Post
+                </p>
+                <p id="in-the-news-date">June 22, 2022</p>
+              </div>
+            </div>
+          </section>
+        </div>
+        <section style="width: 100%">
+          <div id="in-the-news-year-container">
+            <p id="in-the-news-year">2021</p>
+            <span id="in-the-news-line"></span>
+          </div>
+
+          <div class="card mb-2">
+            <div class="card-body" style="justify-content: space-around">
+              <a
+                class="card-title"
+                id="in-the-news-article-title"
+                href="https://ocean.sagepub.com/blog/skills/from-princeton-to-london-via-chicago-my-summer-institute-in-computational-social-science-story"
+                target="_blank"
+              >
+                From Princeton to London via Chicago: My Summer Institute in
+                Computational Social Science journey
+              </a>
+              <p class="my-2" id="in-the-news-subtitle">
+                Posted By: SAGE Ocean Blog
+              </p>
+              <p id="in-the-news-date">March, 8, 2021</p>
+            </div>
+          </div>
+          <div class="card mb-2">
+            <div class="card-body" style="justify-content: space-around">
+              <a
+                class="card-title"
+                id="in-the-news-article-title"
+                href="https://www.demographicscience.ox.ac.uk/post/the-oxford-summer-institute-in-computational-social-science-online-and-a-resounding-success"
+                target="_blank"
+              >
+                The Oxford Summer Institute in Computational Social Science -
+                online and a resounding success!
+              </a>
+              <p class="my-2" id="in-the-news-subtitle">
+                Posted By: Leverhulme Centre for Demographic Science
+              </p>
+              <p id="in-the-news-date">July 29, 2021</p>
+            </div>
+          </div>
+        </section>
+
+        <section style="width: 100%">
+          <div id="in-the-news-year-container">
+            <p id="in-the-news-year">2020</p>
+            <span id="in-the-news-line"></span>
+          </div>
+
+          <div class="card mb-2">
+            <div class="card-body" style="justify-content: space-around">
+              <a
+                class="card-title"
+                id="in-the-news-article-title"
+                href="https://www.research-in-bavaria.de/computational-social-science"
+                target="_blank"
+              >
+                Social Scientist 2.0: Paving the Way in Computational Methods
+              </a>
+              <p class="my-2" id="in-the-news-subtitle">
+                Posted By: University of Bamberg
+              </p>
+              <p id="in-the-news-date">December 2, 2020</p>
+            </div>
+          </div>
+          <div class="card mb-2">
+            <div class="card-body" style="justify-content: space-around">
+              <a
+                class="card-title"
+                id="in-the-news-article-title"
+                href="https://scatter.wordpress.com/2020/11/11/ai-gender-bias-and-computational-social-science/"
+                target="_blank"
+              >
+                ai gender bias and computational social science
+              </a>
+              <p class="my-2" id="in-the-news-subtitle">
+                Posted By: Scatterplot Blog
+              </p>
+              <p id="in-the-news-date">November 11, 2020</p>
+            </div>
+          </div>
+        </section>
+        <section style="width: 100%">
+          <div id="in-the-news-year-container">
+            <p id="in-the-news-year">2019</p>
+            <span id="in-the-news-line"></span>
+          </div>
+
+          <div class="card mb-2">
+            <div class="card-body" style="justify-content: space-around">
+              <a
+                class="card-title"
+                id="in-the-news-article-title"
+                href="https://www.methodspace.com/blog/a-great-measure-of-our-success-is-the-community-that-sicss-creates-chris-bail-and-matt-salganik-on-the-summer-institute-in-computational-social-science"
+                target="_blank"
+              >
+                'A great measure of our success is the community that SICSS
+                creates'. Chris Bail and Matt Salganik on the Summer Institute
+                in Computational Social Science
+              </a>
+              <p class="my-2" id="in-the-news-subtitle">
+                Posted By: Sage Methodpace
+              </p>
+            </div>
+          </div>
+          <div class="card mb-2">
+            <div class="card-body" style="justify-content: space-around">
+              <a
+                class="card-title"
+                id="in-the-news-article-title"
+                href="https://podcasts.apple.com/us/podcast/workshop-on-non-probability-surveys/id1487299051?i=1000458064090"
+                target="_blank"
+              >
+                Workshop on non-probability surveys: Summer Institute in
+                Computational Social Sciences (SICSS) 2019 [Podcast]
+              </a>
+              <p class="my-2" id="in-the-news-subtitle">
+                Posted By: University of Oxford on Apple Podcasts
+              </p>
+              <p id="in-the-news-date">2019</p>
+            </div>
+          </div>
+          <div class="card mb-2">
+            <div class="card-body" style="justify-content: space-around">
+              <a
+                class="card-title"
+                id="in-the-news-article-title"
+                href="https://www.princeton.edu/news/2019/07/16/summer-institute-advances-social-science-digital-age"
+                target="_blank"
+              >
+                Summer institute advances social science in the digital age
+              </a>
+              <p class="my-2" id="in-the-news-subtitle">
+                Posted By: Princeton University News
+              </p>
+              <p id="in-the-news-date">July 16, 2019</p>
+            </div>
+          </div>
+          <div class="card mb-2">
+            <div class="card-body" style="justify-content: space-around">
+              <a
+                class="card-title"
+                id="in-the-news-article-title"
+                href="https://cssh.northeastern.edu/socant/two-phd-students-jeff-sternberg-and-rebekah-getman-accepted-to-the-summer-institute-in-computational-social-science/"
+                target="_blank"
+              >
+                Two PhD Students, Jeff Sternberg and Rebekah Getman, accepted to
+                the Summer Institute in Computational Social Sciences
+              </a>
+              <p class="my-2" id="in-the-news-subtitle">
+                Posted By: Northeastern University Department of Sociology &
+                Anthropology
+              </p>
+              <p id="in-the-news-date">May 7, 2019</p>
+            </div>
+          </div>
+          <div class="card mb-2">
+            <div class="card-body" style="justify-content: space-around">
+              <a
+                class="card-title"
+                id="in-the-news-article-title"
+                href="https://penntoday.upenn.edu/news/echo-chambers-may-not-be-dangerous-you-think"
+                target="_blank"
+              >
+                Echo chambers may not be as dangerous as you think
+              </a>
+              <p class="my-2" id="in-the-news-subtitle">
+                Posted By: University of Pennsylvania Penn Today
+              </p>
+              <p id="in-the-news-date">May 14, 2019</p>
+            </div>
+          </div>
+        </section>
+
+        <section style="width: 100%">
+          <div id="in-the-news-year-container">
+            <p id="in-the-news-year">2018</p>
+            <span id="in-the-news-line"></span>
+          </div>
+
+          <div class="card mb-2">
+            <div class="card-body" style="justify-content: space-around">
+              <a
+                class="card-title"
+                id="in-the-news-article-title"
+                href="https://rajapinta.co/2018/08/06/the-project-week-of-the-summer-institute-for-computational-social-science-at-helsinki/"
+                target="_blank"
+              >
+                The Project Week of the Summer Institute for Computational
+                Social Science at Helsinki
+              </a>
+              <p class="my-2" id="in-the-news-subtitle">Posted By: Rajapinta</p>
+              <p id="in-the-news-date">August 6, 2018</p>
+            </div>
+          </div>
+          <div class="card mb-2">
+            <div class="card-body" style="justify-content: space-around">
+              <a
+                class="card-title"
+                id="in-the-news-article-title"
+                href="https://escience.washington.edu/escience-institute-co-hosts-computational-social-science-conference/"
+                target="_blank"
+              >
+                eScience Institute co-hosts computational social science
+                conference
+              </a>
+              <p class="my-2" id="in-the-news-subtitle">
+                Posted By: University of Washington eScience News
+              </p>
+              <p id="in-the-news-date">2018</p>
+            </div>
+          </div>
+        </section>
+      </div>
+    </section>
+    {% include footer.html %}
+  </body>
+</html>

--- a/_layouts/post-mortem.html
+++ b/_layouts/post-mortem.html
@@ -13,7 +13,7 @@
     <!-- Start content -->
     <section>
       <div class="container default">
-        <h2 class="display-4">Post-Mortems</h2>
+        <h2 class="page-title">POST-MORTEMS</h2>
         <div class="accordion" id="accordionMenu">
           {% for year in locations_by_year %}
           <div id="post-mortem-container">
@@ -31,7 +31,7 @@
               id="post-mortem-year"
             >
               {{year.year}}
-              <span class="collapse-caret"></span>
+              <span class="collapse-caret-black"></span>
             </ul>
             {%else%}
             <ul
@@ -67,6 +67,13 @@
           </div>
           {% endfor %}
         </div>
+
+        <a
+          href="/in-the-news"
+          id="post-mortem-end-link"
+          class="mx-auto d-flex justify-content-center"
+          >SEE ALSO: SICSS - IN THE NEWS</a
+        >
       </div>
     </section>
     {% include footer.html %}

--- a/about.md
+++ b/about.md
@@ -16,7 +16,7 @@ The [Summer Institutes in Computational Social Science (SICSS)](http://sicss.io)
 
 ## Impact
 
-<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="800" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F2hsccqbR0H1tA7hRB42gHJ%2FThe-Growth-of-the-Summer-Institutes-in-Computational-Social-Science%3Ftype%3Dwhiteboard%26node-id%3D0%253A1%26t%3DkvNz7VSxM3VNhiTV-1" allowfullscreen></iframe>
+<iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="100%" height="450" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F2hsccqbR0H1tA7hRB42gHJ%2FThe-Growth-of-the-Summer-Institutes-in-Computational-Social-Science%3Ftype%3Dwhiteboard%26node-id%3D0%253A1%26t%3DkvNz7VSxM3VNhiTV-1" allowfullscreen></iframe>
 
 Since 2017, the Summer Institutes in Computational Social Science in partnership with the Social Science Research Council have raised over $1.5 million (USD) to sponsor sites at fifty-three locations around the world, bringing together 1,046 participants from 500 universities and 150 academic fields. Research incubated at SICSS events has appeared in leading journals and received coverage from  major media outlets. More than 150,000 unique visitors viewed our website from 198 countries during this period. We have almost made considerable progress towards expanding access to training among traditional under-represented groups in the field, including an alumni-led initiative called [Varycss.org](https://varycss.org).
 

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -154,6 +154,24 @@ figure figcaption {
   transform: rotate(0deg);
 }
 
+.collapse-caret-black {
+  display: block;
+  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI1IiBoZWlnaHQ9IjEwIiB2aWV3Qm94PSIwIDAgNSAxMCI+CiAgPHBvbHlnb24gZmlsbD0iIzM0M0E0MCIgZmlsbC1ydWxlPSJldmVub2RkIiBwb2ludHM9IjAgMCA1IDUgMCAxMCIvPgo8L3N2Zz4=");
+  background-size: 5px 10px;
+  background-repeat: no-repeat;
+  background-position: left center;
+  width: 16px;
+  height: 16px;
+  content: "";
+  margin-right: 4px;
+  transition: transform 0.3s;
+  transform-origin: 20% 50%;
+  transform: rotate(90deg);
+}
+.btn-collapse-toggle.collapsed .collapse-caret-black {
+  transform: rotate(0deg);
+}
+
 .breadcrumb {
   background: none;
 }
@@ -225,9 +243,23 @@ figure figcaption {
   gap: 10px;
   align-self: stretch;
 }
+#post-mortem-item:hover{
+  text-decoration: underline;
+}
 #post-mortem-break {
   width: 100%;
   background: rgba(52, 58, 64, 0.50);
+}
+#post-mortem-end-link {
+  color: #005EC2;
+  font-family: Inter;
+  font-size: 16px;
+  font-style: italic;
+  font-weight: 500;
+  line-height: normal;
+  text-decoration-line: underline;
+  text-align: center;
+  margin-bottom: 10px;
 }
 
 #in-the-news-container {

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -67,6 +67,17 @@ a {
   max-width: 80%;
   height: auto;
 }
+
+.page-title {
+  color: #343A40;
+  font-family: Roboto;
+  font-size: 32px;
+  font-style: normal;
+  font-weight: 800;
+  line-height: normal;
+  text-align: center;
+}
+
 figure {
   position: relative;
 }
@@ -219,4 +230,61 @@ figure figcaption {
   background: rgba(52, 58, 64, 0.50);
 }
 
-
+#in-the-news-container {
+  display: flex;
+  width: 100%;
+  // min-width: 390px;
+  // max-width: 991px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 40px;
+  align-self: stretch;
+}
+#in-the-news-year-container {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  align-self: stretch;
+}
+#in-the-news-block {
+  display: flex;
+}
+#in-the-news-year {
+  color: #343A40;
+  font-family: Inter;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: normal;
+}
+#in-the-news-line {
+  width: 100%;
+  height: 1px;
+  background-color: #DADADA;
+  margin-bottom: 12px;
+}
+#in-the-news-article-title {
+  color: #343A40;
+  font-family: Roboto;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+  color: #343A40
+}
+#in-the-news-subtitle {
+  color: #343A40;
+  font-family: Roboto;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+}
+#in-the-news-date {
+  color: #343A40;
+  font-family: Roboto;
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+}

--- a/in-the-news.md
+++ b/in-the-news.md
@@ -1,14 +1,11 @@
 ---
 title: ""
 subtitle: ""
-layout: page
+layout: in-the-news
 ---
 
-<h2 class="display-4">SICSS In The News </h2>
 
----
-
-#### 2023
+<!-- #### 2023
 
 <u>Newhouse Postdoctoral Scholar to Co-Lead Summer Institute</u>
 <br><font color="grey"><font size="2">March 16, 2023</font></font> 
@@ -107,4 +104,4 @@ layout: page
 <u>eScience Institute co-hosts computational social science conference</u>
 <br><font color="grey"><font size="2">2018</font></font> 
 <font size = "1">(Posted by <a href="https://escience.washington.edu/escience-institute-co-hosts-computational-social-science-conference/">University of Washington eScience News</a>)</font>
-
+ -->


### PR DESCRIPTION
This PR mainly modifies the "In the News" page to match the Figma spec:

![Screenshot 2023-09-05 at 6 44 50 PM](https://github.com/compsocialscience/summer-institute/assets/18548300/3d7ee7f4-022b-4405-9b0f-1791d483cc12)

In addition, a few more tweaks were added:

1. Hover underline state has been added to Post-Mortem links
2. Post-Mortem accordion carets that are active have been changed to a darker color
3. The iFrame width of Figma in the "About" page has been modified to match its column